### PR TITLE
Set restart on failure for install script

### DIFF
--- a/installer/package.ps1
+++ b/installer/package.ps1
@@ -229,6 +229,10 @@ function InstallBroker($destfolder, $logFolder, $configFile)
     }
 
     New-Service -Name $serviceName -BinaryPathName "${binary} -logDir ${logFolder} -config ${configFile}" -DisplayName $serviceName -StartupType Automatic
+
+    #set restart on process failure after 15000 milliseconds
+    sc.exe failure $serviceName reset= 0   actions= restart/15000
+
     Start-Service -DisplayName $serviceName
 
     # Setup a firewall rule


### PR DESCRIPTION
This will configure the service to automatically restart on service failures.
Also see: https://github.com/cloudfoundry-incubator/cf-mssql-broker/pull/12 

@florindragos @viovanov can you please check this out