### PR TITLE
Update odbc sql client in installer config to v11

### DIFF
--- a/installer/cf_mssql_broker_config.json
+++ b/installer/cf_mssql_broker_config.json
@@ -32,7 +32,7 @@
 	"brokerMssqlConnection": {
 		"server":   "localhost\\sqlexpress",
 		"database": "master",
-		"driver": 	"sql server"
+		"driver": 	"{SQL Server Native Client 11.0}"
 	},
 
 	"servedMssqlBindingHostname" : "192.168.1.10",


### PR DESCRIPTION
This patch will use the latest version of ODBC driver for the SQL Client.
I did an in-place update to the binary and config to an existing cluster and worked ok.
See also: https://github.com/cloudfoundry-incubator/cf-mssql-broker/pull/12